### PR TITLE
Fix crash after failed global search

### DIFF
--- a/src/regexp_search.c
+++ b/src/regexp_search.c
@@ -72,7 +72,7 @@ __regexp_search(char *pattern, char *string)
 		/* invalid regexp */
 		if (regcomp(&h_regexp[pinfo_re_offset], pattern, flags))
 		{
-			return 0;
+			return -1;
 		}
 		old_pattern = strdup(pattern);
 		old_type = match_type;


### PR DESCRIPTION
Steps to reproduce:
1. `pinfo flex`
2. <kbd>s</kbd> to activate global search
3. Enter `{-}` and press Enter