### PR TITLE
Fix type mismatch when allocating the inodes array

### DIFF
--- a/src/filehandling_functions.c
+++ b/src/filehandling_functions.c
@@ -1033,7 +1033,7 @@ initpaths()
 
 	/* ok, now we have all the (possibly) revelevant paths in paths[] */
 	/* now loop over them, see if they are valid and if they are duplicates*/
-	inodes = (ino_t *) xmalloc( maxpaths * sizeof(ino_t *) );
+	inodes = (ino_t *) xmalloc( maxpaths * sizeof(ino_t) );
 	numpaths = 0;
 	len = 0;
 	for (i=0; i< maxpaths; i++)


### PR DESCRIPTION
This fixes heap-based buffer overflow on systems that have ino_t wider than a pointer.

Fixes: https://bugs.debian.org/922455