### PR TITLE
Fix compiling with -fno-common

### DIFF
--- a/src/parse_config.h
+++ b/src/parse_config.h
@@ -85,8 +85,6 @@ typedef struct colours
 colours;
 #endif /* HAVE_CURSES_COLOR */
 
-int use_manual;
-
 int parse_config (void);
 int parse_line (char *line);
 char *str_toupper (char *s);


### PR DESCRIPTION
GCC 10 will enable -fno-common by default[0], which causes the linker to fail like this [1]:

```
ld: pinfo-colors.o:(.bss+0x34): multiple definition of `use_manual';
pinfo-pinfo.o:(.bss+0x10): first defined here
```

Fix this by removing the extraneous and incorrect definition from `parse_config.h`.

[0] https://gcc.gnu.org/gcc-10/porting_to.html#common
[1] https://bugs.gentoo.org/706548