### PR TITLE
Show the version when the user asks for it, even if the verbose mode is disabled

### DIFF
--- a/src/pinfo.c
+++ b/src/pinfo.c
@@ -188,6 +188,10 @@ main(int argc, char *argv[])
 							argv[0]);
 					exit(0);
 				case 'v':
+					// If the `verbose` option was not enabled, then the version has not been shown
+					// and it has to be shown now
+					if (!verbose)
+						printf("pinfo v%s\n", version);
 					exit(0);
 				case 'm':
 					checksu();


### PR DESCRIPTION
Show the version when the user asks for it, even if the verbose mode is disabled. This solves that bug: https://github.com/baszoetekouw/pinfo/issues/13